### PR TITLE
Add solve option

### DIFF
--- a/hera_filters/dspec.py
+++ b/hera_filters/dspec.py
@@ -198,7 +198,7 @@ def place_data_on_uniform_grid(x, data, weights, xtol=1e-3):
 def _fourier_filter_hash(filter_centers, filter_half_widths, x, w=None, hash_decimal=10, **kwargs):
     """
     Generate a hash key for a fourier filter
-    
+
     Parameters
     ----------
         filter_centers: list,
@@ -1694,7 +1694,7 @@ def _fit_basis_1d(x, y, w, filter_centers, filter_half_widths,
             info['skipped'] = True
 
     else:
-        raise ValueError("Provided 'method', '%s', is not in ['leastsq', 'matrix']."%(method))
+        raise ValueError("Provided 'method', '%s', is not in ['leastsq', 'matrix', 'solve']."%(method))
     model = amat @ (suppression_vector * cn_out)
     resid = (y - model) * (~np.isclose(w, 0, atol=1e-10)).astype(float) #suppress flagged residuals (such as RFI)
     return model, resid, info

--- a/hera_filters/dspec.py
+++ b/hera_filters/dspec.py
@@ -298,6 +298,8 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, mode,
                         'clean', iterative clean
                         'dpss_leastsq', dpss fitting using scipy.optimize.lsq_linear
                         'dft_leastsq', dft fitting using scipy.optimize.lsq_linear
+                        'dpss_solve', dpss fitting using np.linalg.solve
+                        'dft_solve', dft fitting using np.linalg.solve
                         'dpss_matrix', dpss fitting using direct lin-lsq matrix
                                        computation. Slower then lsq but provides linear
                                        operator that can be used to propagate
@@ -1601,6 +1603,7 @@ def _fit_basis_1d(x, y, w, filter_centers, filter_half_widths,
                     filter width instead of a single tone.
     method: string
         specifies the fitting method to use. We currently support.
+            *'solve' derive model using np.linalg.solve
             *'leastsq' to perform iterative leastsquares fit to derive model.
                 using scipy.optimize.leastsq
             *'matrix' derive model by directly calculate the fitting matrix
@@ -1927,6 +1930,7 @@ def _fit_basis_2d(x, data, wgts, filter_centers, filter_half_widths,
                     if 2d fit, should be a list of lists of avg_suppression thressholds for each.
     method: string
         specifies the fitting method to use. We currently support.
+            *'solve' derive model using np.linalg.solve
             *'leastsq' to perform iterative leastsquares fit to derive model.
                 using scipy.optimize.leastsq
             *'matrix' derive model by directly calculate the fitting matrix
@@ -2066,7 +2070,7 @@ def fit_solution_matrix(weights, design_matrix, cache=None, hash_decimal=10, fit
     ----------
     weights: array-like
         ndata x ndata matrix of data weights
-    design_matrx: array-like
+    design_matrix: array-like
         ndata x n_fit_params matrix transforming fit_parameters to data
     cache: optional dictionary
         optional dictionary storing pre-computed fitting matrix.

--- a/hera_filters/dspec.py
+++ b/hera_filters/dspec.py
@@ -2066,6 +2066,8 @@ def fit_solution_matrix(weights, design_matrix, cache=None, hash_decimal=10, fit
     if cache is None:
         cache = {}
     ndata = weights.shape[0]
+    if not weights.shape[0] == weights.shape[1]:
+        raise ValueError("weights must be a square matrix")
     if not design_matrix.shape[0] == ndata:
         raise ValueError("weights matrix incompatible with design_matrix!")
     if fit_mat_key is None:

--- a/hera_filters/dspec.py
+++ b/hera_filters/dspec.py
@@ -197,6 +197,25 @@ def place_data_on_uniform_grid(x, data, weights, xtol=1e-3):
 
 def _fourier_filter_hash(filter_centers, filter_half_widths, x, w=None, hash_decimal=10, **kwargs):
     """
+    Generate a hash key for a fourier filter
+    
+    Parameters
+    ----------
+        filter_centers: list,
+                        list of floats for filter centers
+        filter_half_widths: list
+                        list of float filter half widths (in fourier space)
+        filter_factors: list
+                        list of float filter factors
+        x: the x-axis of the data to be subjected to the hashed filter.
+        w: optional vector of float weights to hash to. default, none
+        hash_decimal: number of decimals to use for floats in key.
+        kwargs: additional hashable elements the user would like to
+                include in their filter key.
+
+    Returns
+    -------
+    A key for fourier_filter arrays hasing the information provided in the args.
     """
     hashkey = hashlib.sha1(np.round(np.ascontiguousarray(x), hash_decimal))
     hashkey.update(np.ascontiguousarray(filter_centers))

--- a/hera_filters/tests/test_dspec.py
+++ b/hera_filters/tests/test_dspec.py
@@ -1141,6 +1141,10 @@ def test__fit_basis_1d():
 
     assert np.all(np.isclose((mod2+resid2)*wgts, dw, atol=1e-6))
 
+    # Check failure mode of np.linalg.solve
+    mod1, resid1, info1 = dspec._fit_basis_1d(fs, dw, np.zeros_like(dw), [0.], [5./50.], basis_options=dpss_opts,
+                                    method='solve', basis='dpss')
+
 def test_fit_basis_1d_with_missing_channels():
     fs = np.arange(-50,50)
     #here is some data

--- a/hera_filters/tests/test_dspec.py
+++ b/hera_filters/tests/test_dspec.py
@@ -1144,6 +1144,16 @@ def test__fit_basis_1d():
     # Check failure mode of np.linalg.solve
     mod1, resid1, info1 = dspec._fit_basis_1d(fs, dw, np.zeros_like(dw), [0.], [5./50.], basis_options=dpss_opts,
                                     method='solve', basis='dpss')
+    assert info1['skipped']
+
+    # Check errors
+    with pytest.raises(ValueError):
+        mod1, resid1, info1 = dspec._fit_basis_1d(fs, dw, np.zeros_like(dw), [0.], [10./3e8], basis_options={'eigenval_cutoff': [1e-12]},
+                                method='undefined', basis='dpss')
+
+    with pytest.raises(ValueError):
+        mod1, resid1, info1 = dspec._fit_basis_1d(fs, dw, np.zeros_like(dw), [0.], [10./3e8], basis_options={'eigenval_cutoff': [1e-12]},
+                                method='solve', basis='undefined')
 
 def test_fit_basis_1d_with_missing_channels():
     fs = np.arange(-50,50)

--- a/hera_filters/tests/test_dspec.py
+++ b/hera_filters/tests/test_dspec.py
@@ -741,6 +741,9 @@ def test_fourier_filter():
     mdl4, res4, info4 = dspec.fourier_filter(freqs, d, w, [0.], [bl_len],
                                              mode='clean', **clean_options1)
 
+    mdl5, res5, info5 = dspec.fourier_filter(freqs, d, w, [0.], [bl_len], suppression_factors=[0.],
+                                             mode='dpss_matrix', **dpss_options1)
+
 
     clean_options_typo = {'tol':1e-9, 'maxiter':100, 'filt2d_mode':'rect',
                     'edgecut_low':0, 'edgecut_hi':0, 'add_clean_residual':False,
@@ -751,6 +754,8 @@ def test_fourier_filter():
 
     assert np.all(np.isclose(mdl3, mdl4, atol=1e-6))
     assert np.all(np.isclose(res3, res4, atol=1e-6))
+    assert np.all(np.isclose(mdl1, mdl5, atol=1e-6))
+    assert np.all(np.isclose(res1, res5, atol=1e-6))
 
     assert np.all(np.isclose(mdl1, mdl2, atol=1e-6))
     assert np.all(np.isclose(res1, res2))

--- a/hera_filters/tests/test_dspec.py
+++ b/hera_filters/tests/test_dspec.py
@@ -742,7 +742,7 @@ def test_fourier_filter():
                                              mode='clean', **clean_options1)
 
     mdl5, res5, info5 = dspec.fourier_filter(freqs, d, w, [0.], [bl_len], suppression_factors=[0.],
-                                             mode='dpss_matrix', **dpss_options1)
+                                             mode='dpss_solve', **dpss_options1)
 
 
     clean_options_typo = {'tol':1e-9, 'maxiter':100, 'filt2d_mode':'rect',


### PR DESCRIPTION
I added the option to use `np.linalg.solve` method to `hera_filters` which provides a roughly 2x speed up on a waterfall of a typical size compared to `leastsq` method as shown below

<img width="1110" alt="Screen Shot 2022-05-24 at 9 41 22 AM" src="https://user-images.githubusercontent.com/17678594/170089990-54641d37-5d3a-4981-a2a9-f0b5d56fb02e.png">

I also modified the `_fourier_filter_hash` function to use `hashlib` instead of storing the full `x` and `weights` arrays. It's about 10x faster than the current hashing function, and it reduces the memory usage of the filter key generated. This might reduce the interpretability of the hash key, but the output of the current `_fourier_filtering_hash` isn't super interpretable anyway. This doesn't provide a huge speed-up when filtering the frequency axis, but provides a ~25% speed-up when calling `_fourier_filter_hash` many times as you would do with FRF.

<img width="1113" alt="Screen Shot 2022-05-24 at 9 39 37 AM" src="https://user-images.githubusercontent.com/17678594/170090944-dd55985f-eddf-45dc-8367-47aec4ebc063.png">
