### PR TITLE
Add manifest file for pip git install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include *.md
+include LICENSE
+include hera_filters/VERSION
+include hera_filters/GIT_INFO

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: uvtools
+name: hera_filters
 channels:
   - conda-forge
   - defaults


### PR DESCRIPTION
Added `MANIFEST.in` for pip install using GitHub link. `VERSION` file wasn't included with the installation. This should fix the installation error in https://github.com/HERA-Team/hera_cal/pull/798.