### PR TITLE
ci: fix deprecated publish version

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,11 +1,16 @@
 [flake8]
 ignore =
-    E203    # No space before colon
+    # No space before colon
+    E203
     W503
-    A003    # Class attribute shadows a python builtin -- not much chance of that causing a problem
-    D401    # First line should be in imperative mood -- cached_properties don't fit this bill.
-    D101    # Missing docstring in public class -- my docstrings are in the __init__ which seems to fail this ?
-    RST210  # Otherwise it flags down **kwargs in docstrings.
+    # Class attribute shadows a python builtin -- not much chance of that causing a problem
+    A003
+    # First line should be in imperative mood -- cached_properties don't fit this bill.
+    D401
+    # Missing docstring in public class -- my docstrings are in the __init__ which seems to fail this ?
+    D101
+    # Otherwise it flags down **kwargs in docstrings.
+    RST210
 # These are the only things currently checked, but should be expanded.
 # Would be much easier to use black.
 select =

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,6 +26,6 @@ jobs:
           ls dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@v1
         with:
           password: ${{ secrets.pypi_password }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: '^uvtools/data/'
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
+  rev: v4.4.0
   hooks:
   - id: trailing-whitespace
   - id: check-added-large-files
@@ -20,19 +20,19 @@ repos:
     args: ['--fix=no']
 
 -   repo: https://github.com/PyCQA/flake8
-    rev: '5.0.4'  # pick a git hash / tag to point to
+    rev: '6.0.0'  # pick a git hash / tag to point to
     hooks:
     -   id: flake8
         additional_dependencies:
           - flake8-quotes
-          - flake8-comprehensions
+#          - flake8-comprehensions
           - flake8-builtins
-          - flake8-eradicate
+          # - flake8-eradicate
           - pep8-naming
           - flake8-docstrings
           - flake8-rst-docstrings
           - flake8-rst
-          - flake8-copyright
+          # - flake8-copyright
 
 # -   repo: https://github.com/psf/black
 #     rev: 22.10.0
@@ -40,19 +40,19 @@ repos:
 #     - id: black
 
 -   repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.9.0
+    rev: v1.10.0
     hooks:
       - id: rst-backticks
 
 - repo: https://github.com/PyCQA/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
   - id: isort
     args: ["--profile", "black"]
 
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.2.2
+  rev: v3.3.1
   hooks:
   -   id: pyupgrade
       args: [--py38-plus]

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+codecov:
+ token: 079d97bf-1eb3-456b-8472-8ad1fe292d53


### PR DESCRIPTION
This fixes a small thing, but more importantly, gives us a new version to tag to make a release.