### PR TITLE
Add option to regularize linear fits

### DIFF
--- a/hera_filters/dspec.py
+++ b/hera_filters/dspec.py
@@ -358,7 +358,9 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, mode, ridg
                         then no regularization is applied. If value is greater than zeros, ridge_alpha is used as 
                         the regularization parameter in ridge regression (specifically the main diagonal of the XTX product
                         is multiplied by a value of (1 + ridge_alpha)). Only used in the following linear modes 
-                        (dpss_leastsq, dft_leastsq, dpss_solve, dft_solve, dpss_matrix, dft_matrix).
+                        (dpss_leastsq, dft_leastsq, dpss_solve, dft_solve, dpss_matrix, dft_matrix). Reasonable values
+                        for ridge_alpha when using the DPSS and DFT modes for inpainting wide gaps are between 1e-5 and 1e-2, 
+                        but will depend on factors such as the noise level in the data and the flagging mask.
                     fit_intercept: bool, optional
                         If true, subtracts off average of the data before fitting model to the data. 
                         Default is False. Can be useful if the data is not centered around zero and 
@@ -652,7 +654,7 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, mode, ridg
                    if fit_intercept:
                        if ndim_data == 1:
                            mean = mean.flatten()
-                           
+
                        model += mean # add back mean of data to the model
 
                    return model, residual, info

--- a/hera_filters/dspec.py
+++ b/hera_filters/dspec.py
@@ -648,7 +648,11 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, mode, ridg
                    if ndim_data == 1:
                        model = model.flatten()
                        residual = residual.flatten()
+
                    if fit_intercept:
+                       if ndim_data == 1:
+                           mean = mean.flatten()
+                           
                        model += mean # add back mean of data to the model
 
                    return model, residual, info

--- a/hera_filters/dspec.py
+++ b/hera_filters/dspec.py
@@ -1762,6 +1762,7 @@ def _fit_basis_1d(x, y, w, filter_centers, filter_half_widths,
     else:
         if method == 'leastsq':
             a = np.dot((np.atleast_2d(w).T * amat).T.conj(), amat)
+            a.flat[::a.shape[0] + 1] *= (1 + ridge_alpha) # add regularization term
             try:
                 res = lsq_linear(a, amat.T.conj().dot(w * y))
                 cn_out = res.x

--- a/hera_filters/dspec.py
+++ b/hera_filters/dspec.py
@@ -355,7 +355,7 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, mode, ridg
                                  subtracted foregrounds with 'clean'.
                     ridge_alpha: float, optional
                         Regularization parameter used in ridge regression. Default is 0, if value is equal to zero, 
-                        then no regularization is applied. If value is greater than zeros, ridge_alpha is used as 
+                        then no regularization is applied. If value is greater , ridge_alpha is used as 
                         the regularization parameter in ridge regression (specifically the main diagonal of the XTX product
                         is multiplied by a value of (1 + ridge_alpha)). Only used in the following linear modes 
                         (dpss_leastsq, dft_leastsq, dpss_solve, dft_solve, dpss_matrix, dft_matrix). Reasonable values
@@ -1657,6 +1657,14 @@ def _fit_basis_1d(x, y, w, filter_centers, filter_half_widths,
                 using scipy.optimize.leastsq
             *'matrix' derive model by directly calculate the fitting matrix
                 [A^T W A]^{-1} A^T W and applying it to the y vector.
+    ridge_alpha: float, optional
+        Regularization parameter used in ridge regression. Default is 0, if value is equal to zero, 
+        then no regularization is applied. If value is greater than zero, ridge_alpha is used as 
+        the regularization parameter in ridge regression (specifically the main diagonal of the XTX product
+        is multiplied by a value of (1 + ridge_alpha)). Only used in the following linear modes 
+        (dpss_leastsq, dft_leastsq, dpss_solve, dft_solve, dpss_matrix, dft_matrix). Reasonable values
+        for ridge_alpha when using the DPSS and DFT modes for inpainting wide gaps are between 1e-5 and 1e-2, 
+        but will depend on factors such as the noise level in the data and the flagging mask.
 
 
     Returns:
@@ -2057,6 +2065,15 @@ def _fit_basis_2d(x, data, wgts, filter_centers, filter_half_widths,
     zero_residual_flags : bool, optional.
         If true, set flagged channels in the residual equal to zero.
         Default is True.
+    ridge_alpha: float, optional
+        Regularization parameter used in ridge regression. Default is 0, if value is equal to zero, 
+        then no regularization is applied. If value is greater than zero, ridge_alpha is used as 
+        the regularization parameter in ridge regression (specifically the main diagonal of the XTX product
+        is multiplied by a value of (1 + ridge_alpha)). Only used in the following linear modes 
+        (dpss_leastsq, dft_leastsq, dpss_solve, dft_solve, dpss_matrix, dft_matrix). Reasonable values
+        for ridge_alpha when using the DPSS and DFT modes for inpainting wide gaps are between 1e-5 and 1e-2, 
+        but will depend on factors such as the noise level in the data and the flagging mask.
+
     Returns
     -------
         model: array-like

--- a/hera_filters/dspec.py
+++ b/hera_filters/dspec.py
@@ -553,7 +553,6 @@ def fourier_filter(x, data, wgts, filter_centers, filter_half_widths, mode, ridg
 
                    if fit_intercept:
                        # subtract off mean of data
-                       print (filter_dims)
                        mean = np.sum(data * wgts, axis=tuple(filter_dims), keepdims=True) / np.sum(wgts, axis=tuple(filter_dims), keepdims=True)
                        data = np.copy(data) # make a copy so we don't modify the original data
                        data -= mean

--- a/hera_filters/tests/test_dspec.py
+++ b/hera_filters/tests/test_dspec.py
@@ -1022,7 +1022,7 @@ def test_regularized_regression():
     assert np.linalg.norm((d - mdl_reg)[~w.astype(bool)]) < np.linalg.norm((d - mdl)[~w.astype(bool)])
 
     # Check that de-meaning the data improves interpolation
-    d += 2 + 2j
+    d += 20 + 20j
 
     mdl_reg_demean, res_reg_demean, _ = dspec.fourier_filter(freqs, d, w, [0.], [700e-9], suppression_factors=[0.],
                                              mode='dpss_solve', ridge_alpha=1e-3, eigenval_cutoff=[1e-12], fit_intercept=True)

--- a/hera_filters/tests/test_dspec.py
+++ b/hera_filters/tests/test_dspec.py
@@ -1021,6 +1021,20 @@ def test_regularized_regression():
     # Check that the regularized regression has a smaller residual norm in the flagged region
     assert np.linalg.norm((d - mdl_reg)[~w.astype(bool)]) < np.linalg.norm((d - mdl)[~w.astype(bool)])
 
+    # Check that de-meaning the data improves interpolation
+    d += 2 + 2j
+
+    mdl_reg_demean, res_reg_demean, _ = dspec.fourier_filter(freqs, d, w, [0.], [700e-9], suppression_factors=[0.],
+                                             mode='dpss_solve', ridge_alpha=1e-3, eigenval_cutoff=[1e-12], fit_intercept=True)
+    mdl_reg, res_reg, _ = dspec.fourier_filter(freqs, d, w, [0.], [700e-9], suppression_factors=[0.],
+                                             mode='dpss_solve', ridge_alpha=1e-3, eigenval_cutoff=[1e-12])
+    
+    # Check that the demeaned regularized regression has a smaller residual norm in the flagged region than
+    # the non-demeaned regularized regression. This is because ridge regression reduces the amplitude of the
+    # coefficients, leading to a near-zero mean in the flagged region, which can be a poor prediction of the
+    # inpainted region given non-zero mean data.
+    assert np.linalg.norm((d - mdl_reg_demean)[~w.astype(bool)]) < np.linalg.norm((d - mdl_reg)[~w.astype(bool)])
+
 
 def test_vis_clean():
     # validate that fourier_filter in various clean modes gives close values to vis_clean with equivalent parameters!

--- a/hera_filters/tests/test_dspec.py
+++ b/hera_filters/tests/test_dspec.py
@@ -1036,7 +1036,7 @@ def test_regularized_regression():
         mdls.append(mdl_reg_demean)
         mdl_reg, res_reg, _ = dspec.fourier_filter(freqs, d, w, [0.], [700e-9], suppression_factors=[0.],
                                                 mode=mode, ridge_alpha=1e-3, eigenval_cutoff=[1e-12])
-        
+
         # Check that the demeaned regularized regression has a smaller residual norm in the flagged region than
         # the non-demeaned regularized regression. This is because ridge regression reduces the amplitude of the
         # coefficients, leading to a near-zero mean in the flagged region, which can be a poor prediction of the


### PR DESCRIPTION
This PR adds the option to regularize linear least squares fits of DPSS and DFT bases to data as is done in `dspec.fourier_filter`. Regularizing these fits is particularly useful in preventing pop-ups as are seen when fitting DPSS basis vectors to data with wide gaps. Here's an example of using regularizing with the DPSS basis on simulated data with a large gap relative to the filter size.

<img width="641" alt="Screenshot 2023-08-22 at 9 57 15 AM" src="https://github.com/HERA-Team/hera_filters/assets/17678594/1cc9ce15-ab2e-411a-93f7-5983e6316761">
