### PR TITLE
Zero out grid points outside of xmin and xmax for pswf_operator

### DIFF
--- a/hera_filters/dspec.py
+++ b/hera_filters/dspec.py
@@ -2364,9 +2364,11 @@ def pswf_operator(
     nterms: list of integers, optional
         integer specifying number of pswf terms to include in each delay fitting block.
     xmin: float, optional
-        Lower bound of the frequency range. If not given, will be calculate from x
+        Lower bound of the frequency range. If not given, will be calculate from x. If xmin is given and
+        the range of x is outside of the range, the filters will be set to zero for those values of x.
     xmax: float, optional
-        Upper bound of the frequency range. If not given, will be calculate from x
+        Upper bound of the frequency range. If not given, will be calculate from x. If xmax is given and
+        the range of x is outside of the range, the filters will be set to zero for those values of x.
     hash_decimal: int
         number of decimals to round for floating point dict keys.
 

--- a/hera_filters/dspec.py
+++ b/hera_filters/dspec.py
@@ -2333,7 +2333,7 @@ def _normalized_legendre(x, kmax):
 
 def pswf_operator(
     x, filter_centers, filter_half_widths, eigenval_cutoff=None, nterms=None,
-    cache=None, xmin=None, xmax=None, hash_decimal=10,
+    cache=None, xmin=None, xmax=None, hash_decimal=10
 ):
     """
     Calculates PSWF operator with multiple delay windows to fit data. Frequencies
@@ -2452,6 +2452,9 @@ def pswf_operator(
                 eigvals = np.abs(np.sqrt(2) * eigenvecs[0, neven] / midpoint[neven])
                 eigvals = (eigvals / eigvals.max()) ** 2
                 nt = np.max(neven[eigvals > eigenval_cutoff[fn]])
+
+                # If x-value is outside of the range, set the filters to zeros
+                pswf_vectors[(xg < -1) | (xg > 1)] = 0
 
                 # Truncate pswf vectors
                 pswf_vectors = pswf_vectors[:, :nt]

--- a/hera_filters/tests/test_dspec.py
+++ b/hera_filters/tests/test_dspec.py
@@ -285,6 +285,9 @@ def test_pswf_operator():
     amat1, ncol1 = dspec.pswf_operator(freqs, [0.], [100e-9], eigenval_cutoff=[1e-9])
     amat2, ncol2 = dspec.pswf_operator(freqs, [0., 100e-9], [100e-9, 100e-9], eigenval_cutoff=[1e-9, 1e-9])
     assert sum(ncol2) == 2 * sum(ncol1)
+    # Check that values outside of xmin and xmax are set to zero
+    amat1, ncol1 = dspec.pswf_operator(freqs, [0.], [100e-9], eigenval_cutoff=[1e-9], xmin=1.475e8, xmax=1.5e8)
+    assert np.isclose(amat1[(freqs < 1.475e8) | (freqs > 1.5e8), :].sum(), 0)
 
 def test_dpss_operator():
     #test that an error is thrown when we specify more then one


### PR DESCRIPTION
`dspec.pswf_operator` currently returns NANs if the requested grid points are outside the bounds of the filters. For some use cases in `hera_cal`, it would be more useful for these values to be zeros. This PR zeros out values of the filters beyond the filter bounds. 