### PR TITLE
Add functions to fit the outer product of bases to 2D arrays

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up ${{ matrix.python-version }}

--- a/hera_filters/dspec.py
+++ b/hera_filters/dspec.py
@@ -2842,7 +2842,7 @@ def _kron_matvec(
     """
     i, j = axis_1_basis.shape[1], axis_2_basis.shape[1]
 
-    # Reshape v into (m, n) matrix using Fortran order to match vectorization
+    # Reshape v into (m, n) matrix
     X = x.reshape((i, j))
 
     # Compute the transformation
@@ -2882,7 +2882,7 @@ def _kron_rmatvec(
     """
     m, n = axis_1_basis.shape[0], axis_2_basis.shape[0]
 
-    # Reshape u into (m, n) matrix using Fortran order and apply W
+    # Reshape u into (m, n) matrix and apply W
     X = (data.reshape((m, n))) * weights
 
     # Compute the transformation

--- a/hera_filters/dspec.py
+++ b/hera_filters/dspec.py
@@ -2811,9 +2811,9 @@ def dayenu_mat_inv(x, filter_centers, filter_half_widths,
     return sdwi_mat
 
 def _kron_matvec(
-    x: np.ndarray, 
-    weights: np.ndarray, 
-    axis_1_basis: np.ndarray, 
+    x: np.ndarray,
+    weights: np.ndarray,
+    axis_1_basis: np.ndarray,
     axis_2_basis: np.ndarray
 )-> np.ndarray:
     """
@@ -2840,20 +2840,20 @@ def _kron_matvec(
         Flattened result of size (m * n,).
     """
     i, j = axis_1_basis.shape[1], axis_2_basis.shape[1]
-    
+
     # Reshape v into (m, n) matrix using Fortran order to match vectorization
     X = x.reshape((i, j))
-    
+
     # Compute the transformation
     Y = (axis_1_basis @ X) @ axis_2_basis.T
-    
+
     # Apply the weight W and return flattened result
     return (Y * weights).ravel()
 
 def _kron_rmatvec(
-    data: np.ndarray, 
-    weights: np.ndarray, 
-    axis_1_basis: np.ndarray, 
+    data: np.ndarray,
+    weights: np.ndarray,
+    axis_1_basis: np.ndarray,
     axis_2_basis: np.ndarray
 ) -> np.ndarray:
     """
@@ -2880,13 +2880,13 @@ def _kron_rmatvec(
         Flattened result of size (i * j,).
     """
     m, n = axis_1_basis.shape[0], axis_2_basis.shape[0]
-    
+
     # Reshape u into (m, n) matrix using Fortran order and apply W
     X = (data.reshape((m, n))) * weights
-    
+
     # Compute the transformation
     Y = (axis_1_basis.T.conj() @ X) @ axis_2_basis.conj()
-    
+
     # Return flattened result
     return Y.ravel()
 
@@ -2920,7 +2920,7 @@ def sparse_linear_fit_2D(
     axis_2_basis : np.ndarray
         Basis basis along the second axis, shape (n, j).
     atol, btol : float, optional, default 1e-10
-        Stopping tolerances for `lsqr`. The algorithm terminates when the 
+        Stopping tolerances for `lsqr`. The algorithm terminates when the
         ``norm(r) <= atol * norm(A) * norm(x) + btol * norm(b)``, where A is the
         implicit Kronecker product of `axis_1_basis` and `axis_2_basis`, and b is the
         flattened `data` array, x is the solution, and r is the residual.
@@ -2959,10 +2959,10 @@ def sparse_linear_fit_2D(
     meta = {}
     # Solve the least-squares problem using LSQR
     (
-        x, 
-        meta['istop'], 
-        meta['iter_num'], 
-        *_ 
+        x,
+        meta['istop'],
+        meta['iter_num'],
+        *_
     )= sparse.linalg.lsqr(
         A=linear_operator,
         b=data.ravel(),
@@ -2987,7 +2987,7 @@ def separable_linear_fit_2D(
     """
     Solves a separable linear least-squares problem using weighted basis basis.
 
-    This function fits the input `data` using a least-squares approach with 
+    This function fits the input `data` using a least-squares approach with
     separable weighting along two axes. The solution is computed using pseudo-inverses.
 
     Parameters:

--- a/hera_filters/dspec.py
+++ b/hera_filters/dspec.py
@@ -2995,7 +2995,7 @@ def separable_linear_fit_2D(
     axis_2_basis: np.ndarray
 ) -> np.ndarray:
     """
-    Solves a separable linear least-squares problem using weighted basis basis.
+    Solves a separable linear least-squares problem using weighted basis.
 
     This function fits the input `data` using a least-squares approach with
     separable weighting along two axes. The solution is computed using pseudo-inverses.

--- a/hera_filters/tests/test_dspec.py
+++ b/hera_filters/tests/test_dspec.py
@@ -1378,7 +1378,7 @@ def test_separable_linear_fit_2D():
     # By construction, the data is separable in the time and frequency directions
     # and the flags are also separable. The fit should be able to recover the
     # true data in the unflagged region.
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(42)
     freq_basis, _ = dspec.dpss_operator(np.linspace(100e6, 200e6, nfreqs), [0], [20e-9], eigenval_cutoff=[1e-12])
     time_basis, _ = dspec.dpss_operator(np.linspace(0, ntimes * 10, ntimes), [0], [1e-3], eigenval_cutoff=[1e-12])
     time_flags = rng.choice([True, False], p=[0.1, 0.9], size=(ntimes, 1))
@@ -1429,7 +1429,7 @@ def test_sparse_linear_fit_2d():
     # By construction, the data is separable in the time and frequency directions
     # and the flags are also separable. The fit should be able to recover the
     # true data in the unflagged region.
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(42)
     freq_basis, _ = dspec.dpss_operator(np.linspace(100e6, 200e6, nfreqs), [0], [20e-9], eigenval_cutoff=[1e-12])
     time_basis, _ = dspec.dpss_operator(np.linspace(0, ntimes * 10, ntimes), [0], [1e-3], eigenval_cutoff=[1e-12])
     time_flags = rng.choice([True, False], p=[0.1, 0.9], size=(ntimes, 1))

--- a/hera_filters/tests/test_dspec.py
+++ b/hera_filters/tests/test_dspec.py
@@ -1402,8 +1402,8 @@ def test_separable_linear_fit_2D():
 
     # Errors should be raised if the data, weights, and bases are not compatible
     pytest.raises(
-        ValueError, 
-        dspec.separable_linear_fit_2D, 
+        ValueError,
+        dspec.separable_linear_fit_2D,
         data=data,
         axis_1_weights=(~time_flags[:, 0]).astype(float),
         axis_2_weights=(~freq_flags[0]).astype(float),
@@ -1412,8 +1412,8 @@ def test_separable_linear_fit_2D():
     )
 
     pytest.raises(
-        ValueError, 
-        dspec.separable_linear_fit_2D, 
+        ValueError,
+        dspec.separable_linear_fit_2D,
         data=data,
         axis_1_weights=(~time_flags[:, 0]).astype(float),
         axis_2_weights=(~freq_flags[0]).astype(float),
@@ -1471,25 +1471,25 @@ def test_sparse_linear_fit_2d():
 
     # Errors should be raised if the data, weights, and bases are not compatible
     pytest.raises(
-        ValueError, 
-        dspec.sparse_linear_fit_2D, 
-        data=data, 
+        ValueError,
+        dspec.sparse_linear_fit_2D,
+        data=data,
         weights=(~flags).astype(float),
         axis_1_basis=time_basis,
         axis_2_basis=time_basis,
     )
     pytest.raises(
-        ValueError, 
-        dspec.sparse_linear_fit_2D, 
-        data=data, 
+        ValueError,
+        dspec.sparse_linear_fit_2D,
+        data=data,
         weights=(~flags).astype(float),
         axis_1_basis=freq_basis,
         axis_2_basis=freq_basis,
     )
     pytest.raises(
-        ValueError, 
-        dspec.sparse_linear_fit_2D, 
-        data=data, 
+        ValueError,
+        dspec.sparse_linear_fit_2D,
+        data=data,
         weights=(~flags).astype(float).T,
         axis_1_basis=time_basis,
         axis_2_basis=freq_basis,

--- a/hera_filters/tests/test_dspec.py
+++ b/hera_filters/tests/test_dspec.py
@@ -1400,6 +1400,27 @@ def test_separable_linear_fit_2D():
     # Check that the fit closely matches to the data
     np.testing.assert_allclose(data[~flags], yf[~flags])
 
+    # Errors should be raised if the data, weights, and bases are not compatible
+    pytest.raises(
+        ValueError, 
+        dspec.separable_linear_fit_2D, 
+        data=data,
+        axis_1_weights=(~time_flags[:, 0]).astype(float),
+        axis_2_weights=(~freq_flags[0]).astype(float),
+        axis_1_basis=freq_basis,
+        axis_2_basis=freq_basis,
+    )
+
+    pytest.raises(
+        ValueError, 
+        dspec.separable_linear_fit_2D, 
+        data=data,
+        axis_1_weights=(~time_flags[:, 0]).astype(float),
+        axis_2_weights=(~freq_flags[0]).astype(float),
+        axis_1_basis=time_basis,
+        axis_2_basis=time_basis,
+    )
+
 def test_sparse_linear_fit_2d():
     # test that separable linear fit works as expected.
     ntimes, nfreqs = 100, 50


### PR DESCRIPTION
This PR implements new methods to fit a 2D array as the outer product of two sets of basis functions. Here, I implement two functions, `separable_linear_fit_2D` for cases when the weighting matrix can be decomposed as an outer product of 1D arrays, and `sparse_linear_fit_2D` which uses `scipy.sparse` to represent the design matrix for more general cases. Both these methods significant;y reduce the memory/computational cost of performing 2D fits compared to forming the design matrix in memory and inverting to perform the fit as is done in `hera_cal.smooth_cal.solve_2D_dpss`. Below is a comparison of the timing on a time/frequency filter of some HERA data

<img width="724" alt="Screenshot 2025-02-05 at 7 08 58 PM" src="https://github.com/user-attachments/assets/3c913315-a92e-47f7-874d-9dbcd45a69e7" />
