### PR TITLE
Add preconditioner to sparse solver

### DIFF
--- a/hera_filters/dspec.py
+++ b/hera_filters/dspec.py
@@ -2987,7 +2987,7 @@ def sparse_linear_fit_2D(
 
         # Compute the preconditioner for the first axis
         XTX_axis_1 = np.dot(axis_1_basis.T.conj() * axis_1_wgts, axis_1_basis)
-        eigenval = sparse.linalg.eigs(XTX_axis_1, k=1, which='SR', return_eigenvectors=False) 
+        eigenval = sparse.linalg.eigs(XTX_axis_1, k=1, which='SR', return_eigenvectors=False)
         axis_1_lambda = eigenval.real * eig_scaling_factor
         axis_1_pcond = np.linalg.pinv(
             XTX_axis_1 + np.eye(XTX_axis_1.shape[0]) * axis_1_lambda
@@ -2995,7 +2995,7 @@ def sparse_linear_fit_2D(
 
         # Compute the preconditioner for the second axis
         XTX_axis_2 = np.dot(axis_2_basis.T.conj() * axis_2_wgts, axis_2_basis)
-        eigenval = sparse.linalg.eigs(XTX_axis_2, k=1, which='SR', return_eigenvectors=False) 
+        eigenval = sparse.linalg.eigs(XTX_axis_2, k=1, which='SR', return_eigenvectors=False)
         axis_2_lambda = eigenval.real * eig_scaling_factor
         axis_2_pcond = np.linalg.pinv(
             XTX_axis_2 + np.eye(XTX_axis_2.shape[0]) * axis_2_lambda

--- a/hera_filters/dspec.py
+++ b/hera_filters/dspec.py
@@ -2931,12 +2931,14 @@ def sparse_linear_fit_2D(
         Maximum number of iterations for `lsqr`, default is None
     precondition_solver : bool, optional, default False
         If True, the solver will apply a preconditioner to the basis matrices before
-        solving the least-squares problem. The preconditioner is computed using the
-        the inverse of the regularized Gramian matrix of the basis matrices. Prior
-        computing the inverse, the eigenvalues of the Gramian matrix are regularized
-        by adding a small value proportional to the smallest eigenvalue. This helps
-        to stabilize the computation of the inverse. The regularization factor is
-        computed as the minimum eigenvalue of the Gramian matrix multiplied by the
+        solving the least-squares problem. This option is useful when the input weights
+        are frequency or time dependent and are either very large or very small, or when
+        the basis matrices are ill-conditioned due to large stretches of zeros. 
+        The preconditioner is computed using the the inverse of the regularized Gramian 
+        matrix of the basis matrices. Prior computing the inverse, the eigenvalues of the 
+        Gramian matrix are regularized by adding a small value proportional to the smallest 
+        eigenvalue. This helps to stabilize the computation of the inverse. The regularization 
+        factor is computed as the minimum eigenvalue of the Gramian matrix multiplied by the
         `eig_scaling_factor` parameter.
     eig_scaling_factor : float, optional, default 1e-1
         Regularization factor for the eigenvalues of the Gramian matrix. The factor

--- a/hera_filters/dspec.py
+++ b/hera_filters/dspec.py
@@ -2935,8 +2935,8 @@ def sparse_linear_fit_2D(
         are frequency or time dependent and are either very large or very small, or when
         the basis matrices are ill-conditioned due to large stretches of zeros.
         The preconditioner is computed using the the inverse of the regularized Gramian
-        matrix of the basis matrices. Prior computing the inverse, the eigenvalues of the
-        Gramian matrix are regularized by adding a small value proportional to the smallest
+        matrix (X^T W X) of the basis matrices. Prior to computing the inverse, the eigenvalues 
+        of the Gramian matrix are regularized by adding a small value proportional to the smallest
         eigenvalue. This helps to stabilize the computation of the inverse. The regularization
         factor is computed as the minimum eigenvalue of the Gramian matrix multiplied by the
         `eig_scaling_factor` parameter.
@@ -2981,7 +2981,7 @@ def sparse_linear_fit_2D(
     if precondition_solver:
         # Compute separate preconditioners for the two axes
         # Start by computing separable weights for the two axes
-        u, s, v = np.linalg.svd(weights, full_matrices=False)
+        u, s, v = sparse.linalg.svd(weights, k=1)
         axis_1_wgts = np.abs(u[:, 0] * np.sqrt(s[0]))
         axis_2_wgts = np.abs(v[0] * np.sqrt(s[0]))
 
@@ -2989,7 +2989,7 @@ def sparse_linear_fit_2D(
         XTX_axis_1 = np.dot(axis_1_basis.T.conj() * axis_1_wgts, axis_1_basis)
         eigenval, _ = np.linalg.eig(XTX_axis_1)
         axis_1_lambda = np.min(
-            eigenval[eigenval.real > np.finfo(eigenval.dtype).eps] * eig_scaling_factor
+            eigenval[eigenval.real > np.finfo(eigenval.dtype).eps].real * eig_scaling_factor
         )
         axis_1_pcond = np.linalg.pinv(
             XTX_axis_1 + np.eye(XTX_axis_1.shape[0]) * axis_1_lambda
@@ -2999,7 +2999,7 @@ def sparse_linear_fit_2D(
         XTX_axis_2 = np.dot(axis_2_basis.T.conj() * axis_2_wgts, axis_2_basis)
         eigenval, _ = np.linalg.eig(XTX_axis_2)
         axis_2_lambda = np.min(
-            eigenval[eigenval.real > np.finfo(eigenval.dtype).eps] * eig_scaling_factor
+            eigenval[eigenval.real > np.finfo(eigenval.dtype).eps].real * eig_scaling_factor
         )
         axis_2_pcond = np.linalg.pinv(
             XTX_axis_2 + np.eye(XTX_axis_2.shape[0]) * axis_2_lambda

--- a/hera_filters/dspec.py
+++ b/hera_filters/dspec.py
@@ -2933,11 +2933,11 @@ def sparse_linear_fit_2D(
         If True, the solver will apply a preconditioner to the basis matrices before
         solving the least-squares problem. This option is useful when the input weights
         are frequency or time dependent and are either very large or very small, or when
-        the basis matrices are ill-conditioned due to large stretches of zeros. 
-        The preconditioner is computed using the the inverse of the regularized Gramian 
-        matrix of the basis matrices. Prior computing the inverse, the eigenvalues of the 
-        Gramian matrix are regularized by adding a small value proportional to the smallest 
-        eigenvalue. This helps to stabilize the computation of the inverse. The regularization 
+        the basis matrices are ill-conditioned due to large stretches of zeros.
+        The preconditioner is computed using the the inverse of the regularized Gramian
+        matrix of the basis matrices. Prior computing the inverse, the eigenvalues of the
+        Gramian matrix are regularized by adding a small value proportional to the smallest
+        eigenvalue. This helps to stabilize the computation of the inverse. The regularization
         factor is computed as the minimum eigenvalue of the Gramian matrix multiplied by the
         `eig_scaling_factor` parameter.
     eig_scaling_factor : float, optional, default 1e-1
@@ -2994,7 +2994,7 @@ def sparse_linear_fit_2D(
         axis_1_pcond = np.linalg.pinv(
             XTX_axis_1 + np.eye(XTX_axis_1.shape[0]) * axis_1_lambda
         )
-        
+
         # Compute the preconditioner for the second axis
         XTX_axis_2 = np.dot(axis_2_basis.T.conj() * axis_2_wgts, axis_2_basis)
         eigenval, _ = np.linalg.eig(XTX_axis_2)

--- a/hera_filters/dspec.py
+++ b/hera_filters/dspec.py
@@ -2987,20 +2987,16 @@ def sparse_linear_fit_2D(
 
         # Compute the preconditioner for the first axis
         XTX_axis_1 = np.dot(axis_1_basis.T.conj() * axis_1_wgts, axis_1_basis)
-        eigenval, _ = np.linalg.eig(XTX_axis_1)
-        axis_1_lambda = np.min(
-            eigenval[eigenval.real > np.finfo(eigenval.dtype).eps].real * eig_scaling_factor
-        )
+        eigenval = sparse.linalg.eigs(XTX_axis_1, k=1, which='SR', return_eigenvectors=False) 
+        axis_1_lambda = eigenval.real * eig_scaling_factor
         axis_1_pcond = np.linalg.pinv(
             XTX_axis_1 + np.eye(XTX_axis_1.shape[0]) * axis_1_lambda
         )
 
         # Compute the preconditioner for the second axis
         XTX_axis_2 = np.dot(axis_2_basis.T.conj() * axis_2_wgts, axis_2_basis)
-        eigenval, _ = np.linalg.eig(XTX_axis_2)
-        axis_2_lambda = np.min(
-            eigenval[eigenval.real > np.finfo(eigenval.dtype).eps].real * eig_scaling_factor
-        )
+        eigenval = sparse.linalg.eigs(XTX_axis_2, k=1, which='SR', return_eigenvectors=False) 
+        axis_2_lambda = eigenval.real * eig_scaling_factor
         axis_2_pcond = np.linalg.pinv(
             XTX_axis_2 + np.eye(XTX_axis_2.shape[0]) * axis_2_lambda
         )

--- a/hera_filters/dspec.py
+++ b/hera_filters/dspec.py
@@ -2987,16 +2987,16 @@ def sparse_linear_fit_2D(
 
         # Compute the preconditioner for the first axis
         XTX_axis_1 = np.dot(axis_1_basis.T.conj() * axis_1_wgts, axis_1_basis)
-        eigenval = sparse.linalg.eigs(XTX_axis_1, k=1, which='SR', return_eigenvectors=False)
-        axis_1_lambda = eigenval.real * eig_scaling_factor
+        eigenval = sparse.linalg.eigs(XTX_axis_1, k=1, which='SM', return_eigenvectors=False)
+        axis_1_lambda = np.abs(eigenval) * eig_scaling_factor
         axis_1_pcond = np.linalg.pinv(
             XTX_axis_1 + np.eye(XTX_axis_1.shape[0]) * axis_1_lambda
         )
 
         # Compute the preconditioner for the second axis
         XTX_axis_2 = np.dot(axis_2_basis.T.conj() * axis_2_wgts, axis_2_basis)
-        eigenval = sparse.linalg.eigs(XTX_axis_2, k=1, which='SR', return_eigenvectors=False)
-        axis_2_lambda = eigenval.real * eig_scaling_factor
+        eigenval = sparse.linalg.eigs(XTX_axis_2, k=1, which='SM', return_eigenvectors=False)
+        axis_2_lambda = np.abs(eigenval) * eig_scaling_factor
         axis_2_pcond = np.linalg.pinv(
             XTX_axis_2 + np.eye(XTX_axis_2.shape[0]) * axis_2_lambda
         )

--- a/hera_filters/dspec.py
+++ b/hera_filters/dspec.py
@@ -2935,7 +2935,7 @@ def sparse_linear_fit_2D(
         are frequency or time dependent and are either very large or very small, or when
         the basis matrices are ill-conditioned due to large stretches of zeros.
         The preconditioner is computed using the the inverse of the regularized Gramian
-        matrix (X^T W X) of the basis matrices. Prior to computing the inverse, the eigenvalues 
+        matrix (X^T W X) of the basis matrices. Prior to computing the inverse, the eigenvalues
         of the Gramian matrix are regularized by adding a small value proportional to the smallest
         eigenvalue. This helps to stabilize the computation of the inverse. The regularization
         factor is computed as the minimum eigenvalue of the Gramian matrix multiplied by the

--- a/hera_filters/dspec.py
+++ b/hera_filters/dspec.py
@@ -2981,7 +2981,7 @@ def sparse_linear_fit_2D(
     if precondition_solver:
         # Compute separate preconditioners for the two axes
         # Start by computing separable weights for the two axes
-        u, s, v = sparse.linalg.svd(weights, k=1)
+        u, s, v = sparse.linalg.svds(weights, k=1)
         axis_1_wgts = np.abs(u[:, 0] * np.sqrt(s[0]))
         axis_2_wgts = np.abs(v[0] * np.sqrt(s[0]))
 

--- a/hera_filters/tests/test_dspec.py
+++ b/hera_filters/tests/test_dspec.py
@@ -1557,7 +1557,7 @@ def test_precondition_sparse_solver():
     axis_1_weights = (~time_flags[:, 0]).astype(float) * rng.integers(1, 10, size=(ntimes,))
     axis_2_weights = (~freq_flags[0]).astype(float)
     wgts = np.outer(axis_1_weights, axis_2_weights)
-    
+
     # Add frequency dependence to the weights to make the problem more ill-conditioned
     wgts *= (freqs / 150e6) ** -3.5
 


### PR DESCRIPTION
This PR adds a preconditioner option to the sparse solver that is helpful for handling cases in which the input weights have large flagging gaps relative to the filter size or the weights are non-binary and frequency/time dependent. Here's comparison of the methods on a simulated case when the flagging mask has large gaps and frequency dependent non-zero weights.

<img width="618" alt="Screenshot 2025-02-13 at 5 35 20 PM" src="https://github.com/user-attachments/assets/6d5f32ca-490d-4476-9a4a-9efa8c6dda59" />
