### PR TITLE
More sensible preconditioner regularization

### DIFF
--- a/hera_filters/dspec.py
+++ b/hera_filters/dspec.py
@@ -2900,7 +2900,7 @@ def sparse_linear_fit_2D(
     btol: float = 1e-10,
     iter_lim: int = None,
     precondition_solver: bool = False,
-    eig_scaling_factor: float = 1e-1,
+    eig_scaling_factor: float = 1e-2,
     **kwargs
 ) -> np.ndarray:
     """

--- a/hera_filters/dspec.py
+++ b/hera_filters/dspec.py
@@ -2938,7 +2938,7 @@ def sparse_linear_fit_2D(
         matrix (X^T W X) of the basis matrices. Prior to computing the inverse, the eigenvalues
         of the Gramian matrix are regularized by adding a small value to the diagonal. This
         value is calculated by computing the cumulative sum of the eigenvalues and selecting
-        the smallest value such that the cumulative sum of the largest eigenvalues is less than 
+        the smallest value such that the cumulative sum of the largest eigenvalues is less than
         1 - `eigenspec_threshold`. This helps to stabilize the computation of the inverse.
     eigenspec_threshold : float, optional, default 1e-3
         Regularization parameters for the eigenvalues of the Gramian matrix. This parameter
@@ -2983,11 +2983,11 @@ def sparse_linear_fit_2D(
         # Start by computing separable weights for the two axes
         with np.errstate(invalid='ignore'):
             axis_1_wgts = np.nanmean(
-                np.where(weights == 0, np.nan, weights), 
+                np.where(weights == 0, np.nan, weights),
                 axis=1, keepdims=True
             )
             axis_2_wgts = np.nanmean(
-                np.where(weights == 0, np.nan, weights / axis_1_wgts), 
+                np.where(weights == 0, np.nan, weights / axis_1_wgts),
                 axis=0, keepdims=True
             )
         axis_1_wgts[~np.isfinite(axis_1_wgts)] = 0.0

--- a/hera_filters/dspec.py
+++ b/hera_filters/dspec.py
@@ -2981,14 +2981,15 @@ def sparse_linear_fit_2D(
     if precondition_solver:
         # Compute separate preconditioners for the two axes
         # Start by computing separable weights for the two axes
-        axis_1_wgts = np.nanmean(
-            np.where(weights == 0, np.nan, weights), 
-            axis=1, keepdims=True
-        )
-        axis_2_wgts = np.nanmean(
-            np.where(weights == 0, np.nan, weights / axis_1_wgts), 
-            axis=0, keepdims=True
-        )
+        with np.errstate(invalid='ignore'):
+            axis_1_wgts = np.nanmean(
+                np.where(weights == 0, np.nan, weights), 
+                axis=1, keepdims=True
+            )
+            axis_2_wgts = np.nanmean(
+                np.where(weights == 0, np.nan, weights / axis_1_wgts), 
+                axis=0, keepdims=True
+            )
         axis_1_wgts[~np.isfinite(axis_1_wgts)] = 0.0
         axis_2_wgts[~np.isfinite(axis_2_wgts)] = 0.0
         axis_1_wgts = np.squeeze(axis_1_wgts)


### PR DESCRIPTION
This PR makes a small change in the computation of the preconditioning matrix. Previously, I had scaled the regularization factor in the preconditioning matrix by the smallest eigenvalues of the Gramian. I think the more proper thing to do is set the cutoff based on when the cumulative sum of the eigenspectrum falls below a certain ratio of the total sum of the eigenspectrum. In the previous implementation, the more poorly conditioned the Gramian is, the less it would be regularized. The default choice for the parameter which controls the ratio is a little ad-hoc, but I chose a default which appeared to work well for a couple of baselines. Here are a couple of figures which show the number of iterations to convergence for the low and high band of a baseline, while varying the `eigenspec_threshold`. 

<img width="487" alt="Screenshot 2025-02-19 at 1 34 54 PM" src="https://github.com/user-attachments/assets/2de484bf-c307-4d21-b7bb-abcc9bb9ea8c" />
<img width="499" alt="Screenshot 2025-02-19 at 1 36 56 PM" src="https://github.com/user-attachments/assets/7f6176f1-3f7a-4adb-a26b-2848ed631c7a" />


This PR also makes a small change to the computation of the separable weights in the same function. This new version more accurately represents the 2D weighting matrix when the weighting matrix contains zeros.