### PR TITLE
Make binary weights checker more strict

### DIFF
--- a/hera_filters/dspec.py
+++ b/hera_filters/dspec.py
@@ -117,8 +117,7 @@ def _are_wgts_binary(wgts):
     Returns:
         Value of True if wgts contains only 1's and 0's
     """
-    binary_total = np.sum(np.isclose(wgts, 0) + np.isclose(wgts, 1))
-    return binary_total == np.prod(wgts.shape)
+    return np.all((wgts == 0) | (wgts == 1))
 
 def place_data_on_uniform_grid(x, data, weights, xtol=1e-3):
     """If possible, place data on a uniformly spaced grid.

--- a/hera_filters/tests/test_dspec.py
+++ b/hera_filters/tests/test_dspec.py
@@ -78,6 +78,10 @@ def test_are_wgts_binary():
     wgts = np.random.uniform(0, 1, size=100)
     assert not dspec._are_wgts_binary(wgts)
 
+    # Binary weights array plus some small number should return False
+    wgts = np.random.choice([0, 1], size=100) + 1e-12
+    assert not dspec._are_wgts_binary(wgts)
+
 def test_delay_filter_2D():
     NCHAN = 128
     NTIMES = 10


### PR DESCRIPTION
In `_fit_basis_1d` there is a branch of code that checks if all the weights in an array are 1's or 0's, and performs a slightly faster least-squares fit if they are. The existing `_are_wgts_binary` checker uses `np.isclose` to check if values are close to either 1's or 0's. However, this can lead to some unexpected behavior if values are close to zero, but not exactly zero. This PR fixes that function by requiring that the values be exactly 1's or 0's to execute that branch of `_fit_basis_1d`.