### PR TITLE
Use hermitian=True as appropriate in np.linalg.pinv

### DIFF
--- a/hera_filters/dspec.py
+++ b/hera_filters/dspec.py
@@ -121,34 +121,35 @@ def _are_wgts_binary(wgts):
 
 
 def _pinv_demote_real(M):
-    """Pseudo-inverse that avoids LAPACK zgesdd convergence failures on
-    complex-but-essentially-real matrices.
+    """Pseudo-inverse that works around LAPACK gesdd convergence failures.
 
-    `np.linalg.pinv` dispatches to LAPACK's zgesdd for complex input, which
-    has known brittle convergence for matrices that are mathematically real
-    but typed as complex (e.g. X^T W X for real X with complex storage,
-    where imaginary parts end up at the ~1e-16 ULP level from complex BLAS
-    rounding). Casting to real before pinv routes through dgesdd, which is
-    robust. Genuinely complex matrices are pinv'd directly.
+    `np.linalg.pinv` dispatches to gesdd, which has been observed to fail
+    `LinAlgError: SVD did not converge` on two related problem classes:
 
-    Tolerance choice for the "essentially real" test:
-        tol = max(M.shape) * eps * max(|M.real|_max, 1)
+    1. Complex-but-essentially-real matrices (e.g. X^H W X for real X with
+       complex storage, where imaginary parts sit at ~1e-16 ULP from complex
+       BLAS rounding). zgesdd is brittle on these; casting to real before
+       pinv routes through dgesdd and resolves it.
 
-    This is scale-invariant, size-aware, and mirrors the `max(M.shape) * eps * sigma`
-    rank-cutoff formula numpy itself uses inside `pinv`. The `max(M.shape) * eps`
-    factor bounds worst-case Wilkinson backward error growth in the N-term inner
-    products that build M (e.g. for an N=200 Gram matrix this is ~4e-14, four orders
-    of magnitude above a single ULP — enough headroom for accumulated zgemm rounding,
-    yet far below any plausible "genuinely complex" signal). The `max(..., 1)` guard
+    2. Some well-conditioned real Hermitian matrices arising from DPSS fits.
+       dgesdd is brittle on these too; passing `hermitian=True` routes pinv
+       through eigh (syevd/heevd) and resolves it.
+
+    Tolerance for both the "essentially real" and "Hermitian within
+    roundoff" tests:
+        tol = max(M.shape) * eps * max(|M|_max, 1)
+
+    Scale-invariant, size-aware, and mirrors the `max(M.shape) * eps * sigma`
+    rank-cutoff formula numpy uses inside `pinv`. The `max(..., 1)` guard
     keeps the bound sensible for near-zero matrices.
     """
-    if np.iscomplexobj(M):
-        eps = np.finfo(M.real.dtype).eps
-        scale = max(np.max(np.abs(M.real)), 1.0)
-        tol = max(M.shape) * eps * scale
-        if np.max(np.abs(M.imag)) <= tol:
-            return np.linalg.pinv(np.real(M)).astype(M.dtype)
-    return np.linalg.pinv(M)
+    eps = np.finfo(M.dtype).eps
+    tol = max(M.shape) * eps * max(float(np.max(np.abs(M))), 1.0)
+    out_dtype = M.dtype
+    if np.iscomplexobj(M) and np.max(np.abs(M.imag)) <= tol:
+        M = np.real(M)
+    is_hermitian = M.shape[0] == M.shape[1] and np.max(np.abs(M - M.conj().T)) <= tol
+    return np.linalg.pinv(M, hermitian=is_hermitian).astype(out_dtype)
 
 
 def place_data_on_uniform_grid(x, data, weights, xtol=1e-3):

--- a/hera_filters/tests/test_dspec.py
+++ b/hera_filters/tests/test_dspec.py
@@ -84,7 +84,9 @@ def test_are_wgts_binary():
 
 
 def test_pinv_demote_real_complex_essentially_real():
-    """Direct unit test for the _pinv_demote_real helper."""
+    """Complex-but-essentially-real matrices are demoted to real before pinv,
+    so the call routes through dgesdd (or eigh, given Hermitian dispatch)
+    rather than zgesdd."""
     rng = np.random.default_rng(0)
     A = rng.standard_normal((50, 10))
     M_real = A.T @ A  # real symmetric PSD
@@ -100,11 +102,74 @@ def test_pinv_demote_real_complex_essentially_real():
     assert np.allclose(Pinv_safe.real, Pinv_real)
     assert np.allclose(Pinv_safe.imag, 0)
 
-    # Genuinely complex input should still go through the unmodified pinv path
+
+def test_pinv_demote_real_genuinely_complex_hermitian():
+    """Genuinely complex Hermitian input is pinv'd directly (no demotion),
+    and the result satisfies the Moore-Penrose identity."""
+    rng = np.random.default_rng(1)
     H = rng.standard_normal((10, 10)) + 1j * rng.standard_normal((10, 10))
-    H = H @ H.conj().T  # Hermitian PSD
+    H = H @ H.conj().T  # Hermitian PSD, non-trivial imaginary part
+
     Pinv_H = dspec._pinv_demote_real(H)
+    assert Pinv_H.dtype == H.dtype
     assert np.allclose(H @ Pinv_H @ H, H, atol=1e-8)
+
+
+def test_pinv_demote_real_hermitian_dispatch(monkeypatch):
+    """`hermitian=True` is passed to np.linalg.pinv when M is (within
+    roundoff) Hermitian, and `hermitian=False` otherwise. The Hermitian
+    path routes through eigh and avoids known gesdd convergence failures
+    on some well-conditioned XᴴWX matrices arising from DPSS fits.
+    """
+    seen = []
+    real_pinv = np.linalg.pinv
+
+    def spy(M, *args, hermitian=False, **kwargs):
+        seen.append(hermitian)
+        return real_pinv(M, *args, hermitian=hermitian, **kwargs)
+
+    monkeypatch.setattr(np.linalg, 'pinv', spy)
+
+    rng = np.random.default_rng(2)
+
+    # Real symmetric -> hermitian=True
+    A = rng.standard_normal((20, 6))
+    seen.clear()
+    dspec._pinv_demote_real(A.T @ A)
+    assert seen == [True]
+
+    # Complex Hermitian -> hermitian=True
+    H = rng.standard_normal((6, 6)) + 1j * rng.standard_normal((6, 6))
+    H = H @ H.conj().T
+    seen.clear()
+    dspec._pinv_demote_real(H)
+    assert seen == [True]
+
+    # Non-Hermitian (real, asymmetric) -> hermitian=False
+    N = rng.standard_normal((6, 6))
+    assert not np.allclose(N, N.T)
+    seen.clear()
+    dspec._pinv_demote_real(N)
+    assert seen == [False]
+
+    # Non-square -> hermitian=False (the Hermitian test must short-circuit
+    # so `M - M.conj().T` is never evaluated on a non-square matrix).
+    R = rng.standard_normal((4, 7))
+    seen.clear()
+    dspec._pinv_demote_real(R)
+    assert seen == [False]
+
+
+def test_pinv_demote_real_tolerance_near_zero():
+    """`max(|M|_max, 1)` guard keeps the tolerance sensible for near-zero
+    matrices: ULP-level imag noise on a near-zero matrix still demotes."""
+    rng = np.random.default_rng(3)
+    M = 1e-300 * rng.standard_normal((6, 6))
+    M = M + M.T  # symmetric
+    Mc = M.astype(np.complex128) + 1j * 1e-16 * rng.standard_normal(M.shape)
+    out = dspec._pinv_demote_real(Mc)
+    assert out.dtype == Mc.dtype
+    assert np.allclose(out.imag, 0)
 
 
 def test_fit_basis_1d_complex_essentially_real_matrix():


### PR DESCRIPTION
This PR uses hermitian=True to help avoid numerical stability issues I've been having in `_pinv_demote_real()` (see #30) on NRAO (but not locally for some reason).

It appears to be slightly slower for very small matrices (maybe 1.5x slower for 10x10) but about 33% faster for ~250x250 real symmetric matrices